### PR TITLE
make two regexps more precise in lecture 10

### DIFF
--- a/lectures/10-regular-expressions.slim
+++ b/lectures/10-regular-expressions.slim
@@ -266,7 +266,7 @@
   annotate:
     log_entry = "[2011-07-22 15:42:12] - GET / HTTP/1.1 200 OK"
 
-    if log_entry =~ /\bHTTP\/1.1 (\d+)/
+    if log_entry =~ /\bHTTP\/1\.1 (\d+)/
       request_status = $1.to_i # =>
     else
       raise "Malformed log entry!"
@@ -350,7 +350,7 @@
 
 = slide 'Примерно решение', 'с рекурсивни групи' do
   annotate:
-    validator = /^(\(car \g<1>*\w*\))*$/
+    validator = /^(\(car (\g<1>*|\w*)\))*$/
 
     valid   = '(car (car (car (car list))))'
     invalid = '(car (car (car list))'


### PR DESCRIPTION
The solution of the problem of nested car expression validation validates more than it should:

``` ruby
[1] pry(main)> validator = /^(\(car \g<1>*\w*\))*$/
=> /^(\(car \g<1>*\w*\))*$/
[2] pry(main)> '(car (car (car (car list)SomeText)))'.match validator
=> #<MatchData
 "(car (car (car (car list)SomeText)))"
 1:"(car (car (car (car list)SomeText)))">
#Alternatively,
[3] pry(main)> validator = /^(\(car (\g<1>*|\w*)\))*$/
=> /^(\(car (\g<1>*|\w*)\))*$/
[4] pry(main)> '(car (car (car (car list)SomeText)))'.match validator
=> nil
[5] pry(main)> '(car (car (car (car list))))'.match validator
=> #<MatchData
 "(car (car (car (car list))))"
 1:"(car (car (car (car list))))"
 2:"list)))">
```
