### PR TITLE
Add 2 new slides about overloading of operators

### DIFF
--- a/lectures/05-classes-objects-enumerable.slim
+++ b/lectures/05-classes-objects-enumerable.slim
@@ -372,6 +372,24 @@
 
     Vector.new(1, 5) + Vector.new(3, 10) # =>
 
+= slide 'Предефинируеми оператори' do
+  p Ето и всички оператори, които можете да предефинирате:
+
+  list:
+    Аритметични оператори `+ - * / % **`
+    Двоични оператори `^ | &`
+    Оператори за сравнение `<= < > >=`
+    Оператори за равенство и разпознаване по шаблон `<=> == === != =~ !~`
+    И още `[] []= >> <<`, както и унарните `+ -`
+      
+= slide 'Забележки относно предефиниране на оператори' do
+  list:
+    Тези оператори не са комутативни! 
+    За всяка операция от вида `a + b` всъщност се извиква `a.+(b)` (методът + от класа на `a`)
+    Операторите от вида `+= >>= &&=` не могат да се предефинират, но действат според очакваното.
+    `a += b` е просто синтаксис за `a = a + b`
+    Можете да предефинирате унарните `+ -` съответно чрез методите `+@ -@`
+
 = slide 'private' do
   annotate:
     class Person
@@ -658,16 +676,16 @@
 
 = slide 'Други методи на Enumerable' do
   pre
-    ' all?          any?        chunk       collect          collect_concat
-      count         cycle       detect      drop             drop_while
-      each_cons     each_entry  each_slice  each_with_index  each_with_object
-      entries       find        find_all    find_index       first
-      flat_map      grep        group_by    include?         inject
-      map           max         max_by      member?          min
-      min_by        minmax      minmax_by   none?            one?
-      partition     reduce      reject      reverse_each     select
-      slice_before  sort        sort_by     take             take_while
-      to_a          zip
+    ' all?        any?          chunk       collect          collect_concat
+      count       cycle         detect      drop             drop_while
+      each_cons   each_entry    each_slice  each_with_index  each_with_object
+      entries     find          find_all    find_index       first
+      flat_map    grep          group_by    include?         inject
+      lazy        map           max         max_by           member?
+      min         min_by        minmax      minmax_by        none?
+      one?        partition     reduce      reject           reverse_each
+      select      slice_before  sort        sort_by          take
+      take_while  to_a          zip
 
   p После ще видите как генерирах тази таблица.
 
@@ -813,22 +831,22 @@
 
 = slide 'Как генерирах таблицата с методите?' do
   pre
-    ' all?          any?        chunk       collect          collect_concat
-      count         cycle       detect      drop             drop_while
-      each_cons     each_entry  each_slice  each_with_index  each_with_object
-      entries       find        find_all    find_index       first
-      flat_map      grep        group_by    include?         inject
-      map           max         max_by      member?          min
-      min_by        minmax      minmax_by   none?            one?
-      partition     reduce      reject      reverse_each     select
-      slice_before  sort        sort_by     take             take_while
-      to_a          zip
+    ' all?        any?          chunk       collect          collect_concat
+      count       cycle         detect      drop             drop_while
+      each_cons   each_entry    each_slice  each_with_index  each_with_object
+      entries     find          find_all    find_index       first
+      flat_map    grep          group_by    include?         inject
+      lazy        map           max         max_by           member?
+      min         min_by        minmax      minmax_by        none?
+      one?        partition     reduce      reject           reverse_each
+      select      slice_before  sort        sort_by          take
+      take_while  to_a          zip
 
 = slide 'Как генерирах таблицата с методите?', 'кодът' do
   example:
     Enumerable.instance_methods.
       sort.
-      map { |name| name.to_s.rjust(16) }.
+      map { |name| name.to_s.ljust(16) }.
       each_slice(5) { |row| puts row.join '' }
 
   p.action


### PR DESCRIPTION
Listed all the operators, which can be redefined. Used information from the following sources:
http://ruby.about.com/od/oo/ss/Overloading-Operators.htm
http://phrogz.net/programmingruby/language.html#table_18.4

Also corrected the outdated list of instance methods of Enumerable (lazy was missing).
