### PR TITLE
Lectures swipe area range

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -59,7 +59,9 @@ nav button { float: left; border: 0; width: 26px; height: 25px; text-indent: -99
 .slide .fullscreen { position: absolute; left:0; top:0; width:100%; z-index:1; }
 
 /* Additional styles */
-body{ background:#f5f6f6; }
+html,
+body { background: #f5f6f6; height: 100%; }
+#deck { min-height: 100%; }
 #deck h1 { font-family: 'Marker Felt', Impact, Arial, sans-serif; font-size:50px; text-shadow: 0px 1px 0px rgba(255, 255, 255, 0.8); }
 #deck h2 { font-family: 'Marker Felt', Impact, Arial, sans-serif; font-size: 30px; text-shadow: 0px 1px 0px rgba(255, 255, 255, 0.8); }
 #deck p,

--- a/html/js/htmlSlides.js
+++ b/html/js/htmlSlides.js
@@ -76,7 +76,7 @@ var htmlSlides = {
     });
 
     //Swipe gestures
-    $('.slide').swipe({
+    $('#deck').swipe({
       threshold: {
         x: 20,
         y: 30


### PR DESCRIPTION
Hey guys : )

2 days ago I tried to take a look at one of the presentations using my phone. Everything works fine except the moment when I realised that the swipe plugin is set to watch over the **.slide** class which is not taking the whole screen and because of this I have to swipe over the content. See the image below : )

![Screenshot](http://s11.postimg.org/lpkoct603/Screen_Shot_2013_10_26_at_10_19_36_AM.png)
And this swipe thing makes me sad : ( (It's not really user friendly)  
So I edited height of the **#deck** container to cover the whole screen and set the swipe plugin to watch over it.
I tested it on my local/remote servers with chrome's swipe emulator/phone/tablet and everything looks ok : ). You can test it [here](http://test.georgieff.it/compiled-lectures/01-introduction-to-ruby.html) or here:   

![QR](http://chart.apis.google.com/chart?cht=qr&chs=300x300&chl=http%3A//test.georgieff.it/compiled-lectures/01-introduction-to-ruby.html&chld=H|0)  

If you're having any suggestions for another solution just ping me. This solution looks like will be overwritten if you update the slider plugin : ). 

p.s. sorry about the 2 commits... forgot to rebase : )
