### PR TITLE
Split slide `Kernel#set_trace_func`

### DIFF
--- a/lectures/10-introspection-part-2-metaprogramming-part-1.slim
+++ b/lectures/10-introspection-part-2-metaprogramming-part-1.slim
@@ -162,12 +162,12 @@
         c-call t.rb:8     method_added          Module
       c-return t.rb:8     method_added          Module
            end t.rb:11
-                                ...
+      (Продължава на следващия слайд...)
 
 = slide 'Kernel#set_trace_func', 'Резултати' do
   pre
     |
-      (Продължение...)
+      (Продължение от предишния слайд...)
           line t.rb:13
         c-call t.rb:13             new           Class
         c-call t.rb:13      initialize     BasicObject


### PR DESCRIPTION
Split slide `Kernel#set_trace_func` as full content wasn't visible at normal zoom level.
