### PR TITLE
Fix the URL of the first lecture

### DIFF
--- a/lectures/index.yml
+++ b/lectures/index.yml
@@ -1,7 +1,7 @@
 0:
   title: 00. За курса
   date: 2014-10-01
-  url: https://speakerdeck.com/rbfmi/proghramiranie-s-ruby-liektsiia-0
+  url: https://speakerdeck.com/rbfmi/proghramiranie-s-ruby-2014-liektsiia-0
 1:
   title: 01. Въведение в Ruby
   date: 2014-10-06


### PR DESCRIPTION
Someone pointed out that the URL of the first lecture is wrong. I had
changed the name of the lecture at speakerdeck and that changed the URL.
