### PR TITLE
Fix GitHub links syntax in lecture 02

### DIFF
--- a/lectures/02-challenge-review-pull-requests.slim
+++ b/lectures/02-challenge-review-pull-requests.slim
@@ -22,7 +22,7 @@
     Лекциите са там, задачите са там, форумите са там, животът ви е там
     Регистрацията е задължителна, ако ще участвате в курса
     За записали курса в СУСИ след 1-ви октомври или за хора извън ФМИ, ни пишете на [fmi@ruby.bg](mailto:fmi@ruby.bg)
-    Лекциите ги има и в GitHub — #{github_repo 'fmi/ruby-lectures'}
+    Лекциите ги има и в [GitHub](https://github.com/fmi/ruby-lectures)
 
 = slide 'Бонус точки', 'отвъд сникерсите (последно напомняне)' do
   p Първите ви точки:
@@ -238,7 +238,7 @@
 
 = slide 'Стил' do
   list:
-    Имаме style guide на #{github_repo 'fmi/ruby-style-guide'}
+    Имаме style guide на [https://github.com/fmi/ruby-style-guide](https://github.com/fmi/ruby-style-guide)
     Искаме да го спазвате в първа задача колкото можете повече
 
 = slide 'Споделяне на решения', 'a.k.a. преписване' do


### PR DESCRIPTION
The two links should work properly now.
