### PR TITLE
Fix semantic issues in slide #19 

### DIFF
--- a/lectures/08-enumerators-lazy-freeze-class-methods-gems-spelunking.slim
+++ b/lectures/08-enumerators-lazy-freeze-class-methods-gems-spelunking.slim
@@ -204,7 +204,7 @@
 
     words # =>
 
-= slide 'Каква е разликата?', 'Брой на думите в изречение' do
+= slide 'Каква е разликата?', 'Брой на думите във всеки ред от даден низ' do
   annotate:
     data = "Some really long\ntext with new lines."
 


### PR DESCRIPTION
Видях, че дадените решения не решават точно този проблем, който е описан в описанието под заглавието и реших да го поправя. Също така, смених името на аргумента в при блока в map на line вместо l - мисля, че така наименувано е по-разбираемо и семантично.

Screenshot:

![screenshot from 2014-11-03 22 50 31](https://cloud.githubusercontent.com/assets/1996948/4890144/3cda57d8-639c-11e4-8105-089291d213e2.png)
