### PR TITLE
Correct typo in lecture 4, slide 84

### DIFF
--- a/lectures/04-procs-classes-modules-enumerable.slim
+++ b/lectures/04-procs-classes-modules-enumerable.slim
@@ -982,7 +982,7 @@
               select { |digit| digit.event? }
 
 = slide '#lazy' do
-  p Има една хватка, особено одобна за безкрайни функции:
+  p Има една хватка, особено удобна за безкрайни функции:
 
   example:
     def each_number


### PR DESCRIPTION
Corrected 'особено одобна' to 'особено удобна'.