### PR TITLE
changed the sample implementation of to_proc to use proc instead of lambda

### DIFF
--- a/lectures/06-namespaces-class-methods-assignment-symbol-to-proc.slim
+++ b/lectures/06-namespaces-class-methods-assignment-symbol-to-proc.slim
@@ -419,7 +419,7 @@
   example:
     class Symbol
       def to_proc
-        ->(object, *args) { object.public_send self, *args }
+        proc { |object, *args| object.public_send self, *args }
       end
     end
 


### PR DESCRIPTION
The sample implementation of to_proc (slide 34) now uses proc instead of lambda.